### PR TITLE
Added short circuit var to measure_js to allow for setting it to false

### DIFF
--- a/lib/generator/execution.rb
+++ b/lib/generator/execution.rb
@@ -20,6 +20,7 @@ module HQMF2JS
           var effective_date = <%= effective_date %>;
           var enable_logging = <%= enable_logging %>;
           var enable_rationale = <%= enable_rationale %>;
+          var short_circuit = <%= short_circuit %>;
 
         <% if (!test_id.nil? && test_id.class==Moped::BSON::ObjectId) %>
           var test_id = new ObjectId(\"<%= test_id %>\");


### PR DESCRIPTION
Rationale calculation was going wrong because we couldn't set short_circuit to false, because there was no variable for it in `Hqmf2JS/Generator/Execution`'s `measure_js` function. 
