### PR TITLE
Update TIMEDIFF to handle groupings, using first and last events

### DIFF
--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -1050,6 +1050,7 @@ DATEDIFF = (events, range) ->
 # combination of events
 TIMEDIFF = (events, range, initialSpecificContext) ->
   if events.listCount() != 2
+    # handle nested events for Unions
     if events.length >= 2
       event1 = events.sort(dateSortAscending)[0]
       event2 = events.sort(dateSortAscending)[events.length - 1]


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/78912202 (measure for testing attached to story)
### Notes
- resolved issues with DATETIMEDIFF:
  - updated TIMEDIFF to handle UNIONs/groupings 
  - OBSERV results with Objects are a misuse of DATETIMEDIFF with a PQ comparison within a Measure Observation (DATETIMEDIFF with a PQ comparison == DATEDIFF, which has typically been used as a Boolean expression)
  - missing DATETIMEDIFF clauses are a result of missing aggregators on Measure Observation populations
