### PR TITLE
Remodel expired js to match birthtime js

### DIFF
--- a/lib/generator/characteristic.js.erb
+++ b/lib/generator/characteristic.js.erb
@@ -21,7 +21,7 @@
       <%- end -%>
     <%- end -%>
   events.specificContext=events.specificContext||hqmf.SpecificsManager.identity();
-  return events
+  return events;
 <%- elsif criteria.property == :clinicalTrialParticipant -%>
   matching = matchingValue(value, 'true');
   matching.specificContext=hqmf.SpecificsManager.identity();

--- a/test/unit/hqmf_from_json_javascript_test.rb
+++ b/test/unit/hqmf_from_json_javascript_test.rb
@@ -60,6 +60,7 @@ class HqmfFromJsonJavascriptTest < Test::Unit::TestCase
     assert !@context.eval("hqmfjs.dead3MonthsAfterMeasurePeriod(numeratorPatient).isTrue()")
     assert !@context.eval("hqmfjs.deadBetween5and6MonthsDuringMeasurePeriod(numeratorPatient).isTrue()")
     
+    @context.eval("numeratorPatient.json['expired']=true")
     @context.eval("numeratorPatient.json['deathdate']=#{Time.utc(2010,11).to_i}")
     assert !@context.eval("hqmfjs.dead3MonthsBeforeMeasurePeriod(numeratorPatient).isTrue()")
     assert !@context.eval("hqmfjs.dead3MonthsAfterMeasurePeriod(numeratorPatient).isTrue()")


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/78295724
### Notes
- updated generated JS for `expired` to align with `birthtime`
- resolve issues with Patient Characteristic Expired within grouping with temporal references
