### PR TITLE
always evaluate the RHS on a temporal reference if not short circuiting

### DIFF
--- a/lib/generator/data_criteria.js.erb
+++ b/lib/generator/data_criteria.js.erb
@@ -28,7 +28,7 @@ hqmfjs.<%= js_name(criteria) %> = function(patient, initialSpecificContext) {
     <%- end -%>
     <%- if criteria.temporal_references and criteria.temporal_references.length > 0 -%>
       <%- criteria.temporal_references.each do |temporal_reference| -%>
-  if (events.length > 0 || !short_circuit) events = <%= temporal_reference.type %>(events, hqmfjs.<%= temporal_reference.reference.id %>(patient)<%= ", #{js_for_bounds(temporal_reference.range)}" if temporal_reference.range %>);
+  if (events.length > 0 || !Logger.short_circuit) events = <%= temporal_reference.type %>(events, hqmfjs.<%= temporal_reference.reference.id %>(patient)<%= ", #{js_for_bounds(temporal_reference.range)}" if temporal_reference.range %>);
       <%- end -%>
   if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();
     <%- else # no temporal refs -%>


### PR DESCRIPTION
## Story
- https://www.pivotaltracker.com/story/show/77124046
## Notes

Addresses patients/measures that contain a union on a temporal reference having no left hand side data for the patient. This allows the union to correctly evaluate to false and get included in the rationale. 
