### PR TITLE
Fix select concurrent

### DIFF
--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -93,7 +93,7 @@ class TS
       a.getTime() > b.getTime()
 
   equals: (other) ->
-    (@date==null && other.date==null) || (@date.getTime()==other.date.getTime())
+    (@date==null && other.date==null) || (@date!=null && other.date!=null && @date.getTime()==other.date.getTime())
 
   # Returns whether this TS is before or concurrent with the supplied TS ignoring seconds
   beforeOrConcurrent: (other) ->  
@@ -458,7 +458,8 @@ class IVL_TS
      this.EAS(other) ||  this.ECWS(other)
 
   equals: (other) ->
-    (@low==null && other.low==null) || (@low.equals(other.low)) && (@high==null && other.high==null) || (@high.equals(other.high))
+    ((@low == null && other.low == null) || (@low != null && @low.equals(other.low))) &&
+    ((@high == null && other.high == null) || (@high != null && @high.equals(other.high)))
 
 @IVL_TS = IVL_TS
 


### PR DESCRIPTION
### Story

https://www.pivotaltracker.com/story/show/80642438
### Notes
- When selecting concurrent events, we now use the same criteria used for sorting to determine whether events are concurrent for the purpose of FIRST, etc
- The equals operators for TS and IVL_TS (which may in fact no longer be used with the changes to selecting concurrent events) didn't correctly handle null dates, and had some other issues as well
