### PR TITLE
Specific Occurrence Hash Deduplication

### DIFF
--- a/app/assets/javascripts/specifics.js.coffee
+++ b/app/assets/javascripts/specifics.js.coffee
@@ -232,11 +232,14 @@ class hqmf.SpecificOccurrence
   
   intersect: (other, episodeIndices) ->
     value = new hqmf.SpecificOccurrence()
+    values = {}
     for leftRow in @rows
       for rightRow in other.rows
         result = leftRow.intersect(rightRow, episodeIndices)
-        value.rows.push(result) if result?
-    value.removeDuplicateRows()
+        values[result.toString()] = result if result?
+    for own key, val of values
+      value.rows.push(val)
+    value
   
   getLeftMost: ->
     leftMost = undefined
@@ -502,6 +505,9 @@ class Row
       else
         result.push(value.id)
     result
+
+  toString: ->
+    this.flattenToIds().join(", ")
 
   
 @Row = Row


### PR DESCRIPTION
Updated specificOccurrence intersections to deduplicate rows using a hash, rather than the removeDuplicateRows() method, as for the number of rows being intersected for a patient in CMS117 (patient had 34 medication objects), the method was too inefficient.
