### PR TITLE
Fixed bug that prevented passing false values for includeEventsWithoutStatus

### DIFF
--- a/lib/generator/patient_data.js.erb
+++ b/lib/generator/patient_data.js.erb
@@ -14,7 +14,7 @@
 <%- end -%>
   var eventCriteria = {"type": "<%= eventType %>"<%- -%>
 <%= ", \"statuses\": #{statuses}" if statuses %> <%- -%>
-<%= ", \"includeEventsWithoutStatus\": #{includeEventsWithoutStatus}" if includeEventsWithoutStatus %> <%- -%>
+<%= ", \"includeEventsWithoutStatus\": #{includeEventsWithoutStatus}" unless includeEventsWithoutStatus.nil? %> <%- -%>
 <%= ", \"negated\": #{criteria.negation}" if criteria.negation %> <%- -%>
 <%= ", \"negationValueSetId\": \"#{negationValueSetId}\"" if criteria.negation && negationValueSetId %> <%- -%>
 <%= ", \"valueSetId\": \"#{valueSetId}\"" if valueSetId %> <%- -%>


### PR DESCRIPTION
Explicit false values were not being passed, which prevented event filters from correctly applying the status aspect of the filter when events without status were not desired.