### PR TITLE
Only store finalSpecifics if rationale is enabled

### DIFF
--- a/lib/assets/javascripts/libraries/map_reduce_utils.js
+++ b/lib/assets/javascripts/libraries/map_reduce_utils.js
@@ -68,7 +68,14 @@ root.extract_payer = function(record) {
 root.calculate = function(record, population, denominator, numerator, exclusion, denexcep, occurrenceId, value, stratification) {
   
   finalSpecifics = {};
-  value = _.extend(value, {IPP: 0, DENOM: 0, NUMER: 0, DENEXCEP: 0, DENEX: 0, antinumerator: 0, finalSpecifics: finalSpecifics});
+  value = _.extend(value, {IPP: 0, DENOM: 0, NUMER: 0, DENEXCEP: 0, DENEX: 0, antinumerator: 0});
+
+  // For the moment, we are doing this to allow for the disabling of storage of finalSpecifics in Mongo.
+  // At some point, it may make more sense to move this to its own variable, rather than using enable_rationale
+  // For example, if Cypress starts running into finalSpecifics size issues.
+  if (Logger.enable_rationale) {
+    value = _.extend(value, {finalSpecifics: finalSpecifics});
+  }
 
   var strat;
   var ipp;
@@ -133,8 +140,15 @@ root.calculate = function(record, population, denominator, numerator, exclusion,
 
 root.calculateCV = function(record, population, msrpopl, observ, occurrenceId, value, stratification) {
   finalSpecifics = {};
-  value = _.extend(value, {MSRPOPL: 0, values: [], finalSpecifics: finalSpecifics});
+  value = _.extend(value, {MSRPOPL: 0, values: []});
   
+  // For the moment, we are doing this to allow for the disabling of storage of finalSpecifics in Mongo.
+  // At some point, it may make more sense to move this to its own variable, rather than using enable_rationale
+  // For example, if Cypress starts running into finalSpecifics size issues.
+  if (Logger.enable_rationale) {
+    value = _.extend(value, {finalSpecifics: finalSpecifics});
+  }
+
   var strat;
   var ipp;
   var validStrat = false;

--- a/lib/generator/execution.rb
+++ b/lib/generator/execution.rb
@@ -116,7 +116,9 @@ module HQMF2JS
           // turn on logging if it is enabled
           if (enable_logging || enable_rationale) {
             injectLogger(hqmfjs, enable_logging, enable_rationale, short_circuit);
-          } 
+          } else {
+            Logger.enable_rationale = false;
+          }
         }
 
         try {


### PR DESCRIPTION
Added code to only store the finalSpecifics if rationale is enabled, and code to disable rationale in the Logger if it's passed in as false to HQMF2JS.