### PR TITLE
When intersecting events specifics shouldn't include logically excluded ...

### DIFF
--- a/app/assets/javascripts/specifics.js.coffee
+++ b/app/assets/javascripts/specifics.js.coffee
@@ -273,6 +273,13 @@ class hqmf.SpecificOccurrence
       newRows.push(myRow) if goodRow
     new hqmf.SpecificOccurrence(newRows)
   
+  # Given a set of events and a specific occurrence, return new specifics removing any
+  # rows containing one of the supplied events at the index of that specific occurrence
+  excludeEventsForSpecific: (events, occurrenceID) ->
+    eventIndex = hqmf.SpecificsManager.getColumnIndex(occurrenceID)
+    rowsToKeep = _(@rows).reject (row) -> _(events).include(row.values[eventIndex])
+    new hqmf.SpecificOccurrence(rowsToKeep)
+
   hasRow: (row) ->
     found = false
     for myRow in @rows


### PR DESCRIPTION
If the logical evaluation of an INTERSECT excludes an event, the resulting specifics should not include rows that refer to that event where the specific comes from the leftmost of one of the inputs to the INTERSECT.

This addresses https://jira.oncprojectracking.org/browse/BONNIE-64
