### PR TITLE
When a result criteria is negated, it doesn't have a result value

### DIFF
--- a/lib/generator/data_criteria.js.erb
+++ b/lib/generator/data_criteria.js.erb
@@ -17,8 +17,8 @@ hqmfjs.<%= js_name(criteria) %> = function(patient, initialSpecificContext) {
     <%- end -%>
     <%- if criteria.value -%>
   events = filterEventsByValue(events, <%= js_for_bounds(criteria.value) %>);
-    <%- elsif is_result_criteria(criteria) -%>
-  // force a check of results for result types so that performed does not bleed into results
+    <%- elsif is_result_criteria(criteria) && !criteria.negation -%>
+  // force a check of results for non-negated result types so that performed does not bleed into results
   events = filterEventsByValue(events, new ANYNonNull());
     <%- end -%>
     <%- if criteria.field_values.present?


### PR DESCRIPTION
Fixes https://jira.oncprojectracking.org/browse/BONNIE-86

In previous versions of the QDM (pre 4.0), there was a Diagnostic Study, Result datatype, which per the QDM was actually allowed to have a negation, which means there would in fact be no result. This small tweak changes how result datatypes are handled when negated so that a result is not required.