### PR TITLE
Use empty instead of identity as default specifics for empty sets and falsy values

### DIFF
--- a/lib/generator/execution.rb
+++ b/lib/generator/execution.rb
@@ -121,6 +121,7 @@ module HQMF2JS
             injectLogger(hqmfjs, enable_logging, enable_rationale, short_circuit);
           } else {
             Logger.enable_rationale = false;
+            Logger.short_circuit = short_circuit;
           }
         }
 


### PR DESCRIPTION
The basic issue is that we had empty results with identity specifics, which doesn't particularly make sense and caused problems elsewhere. We address this by changing the default for falsy results to be empty specifics instead of identity.

Using empty specifics for empty results does run into a problem: if we test for COUNT = 0 on the empty set, we wind up changing a falsy value to a truthy one, in which case we'd like the default specifics to again be identity instead of empty. We handle this generally in the maintainSpecifics function.

Finally, we also make a small tweak to how the default value of short_circuit is handled when we're not logging or tracking rationale: the change is to always use the passed in value rather than the Logger default (which is short_circuit: true). Would a better change be to change the Logger default?

FYI the all patients regression test passes.
