### PR TITLE
make patient.payer() compare against valid values

### DIFF
--- a/lib/generator/characteristic.js.erb
+++ b/lib/generator/characteristic.js.erb
@@ -26,8 +26,12 @@
   matching = matchingValue(value, 'true');
   matching.specificContext=hqmf.SpecificsManager.identity();
   return matching;
-<%- elsif criteria.property == :race -%>
-  matching = new Boolean(value.includedIn(<%=criteria.inline_code_list.to_json%>));
+<%- elsif criteria.property == :race || criteria.property == :payer -%>
+  if (value === null) {
+    matching = new Boolean(false);
+  } else {
+    matching = new Boolean(value.includedIn(<%=criteria.inline_code_list.to_json%>));
+  }
   matching.specificContext=hqmf.SpecificsManager.identity();
   return matching;
 <%- else -%>


### PR DESCRIPTION
The previous implementation had patient.payer() always compare against a null value. This change makes it so patient payer compares against the list of values in `inline_code_list`.