### PR TITLE
Changed logic default for MSRPOPL to return true

### DIFF
--- a/lib/generator/js.rb
+++ b/lib/generator/js.rb
@@ -231,7 +231,7 @@ module HQMF2JS
         #{js_for(population[HQMF::PopulationCriteria::DENEX], HQMF::PopulationCriteria::DENEX)}
         #{js_for(population[HQMF::PopulationCriteria::DENEXCEP], HQMF::PopulationCriteria::DENEXCEP)}
         // CV
-        #{js_for(population[HQMF::PopulationCriteria::MSRPOPL], HQMF::PopulationCriteria::MSRPOPL)}
+        #{js_for(population[HQMF::PopulationCriteria::MSRPOPL], HQMF::PopulationCriteria::MSRPOPL, true)}
         #{js_for(population[HQMF::PopulationCriteria::MSRPOPLEX], HQMF::PopulationCriteria::MSRPOPLEX)}
         #{js_for(population[HQMF::PopulationCriteria::OBSERV], HQMF::PopulationCriteria::OBSERV)}
         // VARIABLES


### PR DESCRIPTION
Made it so MSRPOPL returns true if there is no logic there. This makes sense as it should inherit from the IPP if there's no logic. This addresses a bug from Angela Flanegan (2/5/2016)