### PR TITLE
Moved observations below msrpoplex exclusion

### DIFF
--- a/lib/assets/javascripts/libraries/map_reduce_utils.js
+++ b/lib/assets/javascripts/libraries/map_reduce_utils.js
@@ -189,17 +189,18 @@ root.calculateCV = function(record, population, msrpopl, msrpoplex, observ, occu
       var measurePopulation = hqmf.SpecificsManager.intersectSpecifics(msrpopl(), ipp, occurrenceId);
       hqmf.SpecificsManager.storeFinal('MSRPOPL', measurePopulation, finalSpecifics);
       if (hqmf.SpecificsManager.validate(measurePopulation)) {
-
-        var observations = observ(measurePopulation.specificContext);
         value.MSRPOPL = hqmf.SpecificsManager.countUnique(occurrenceId, measurePopulation);
-        value.values = observations;
-
+        
         var measurePopulationExclusions = hqmf.SpecificsManager.intersectSpecifics(msrpoplex(), measurePopulation, occurrenceId);
         hqmf.SpecificsManager.storeFinal('MSRPOPLEX', measurePopulationExclusions, finalSpecifics);
         if (hqmf.SpecificsManager.validate(measurePopulationExclusions)) {
           value.MSRPOPLEX = hqmf.SpecificsManager.countUnique(occurrenceId, measurePopulationExclusions);
+          // Remove from measure population if in measure population exclusion.
           measurePopulation = hqmf.SpecificsManager.exclude(occurrenceId, measurePopulation, measurePopulationExclusions);
         }
+
+        var observations = observ(measurePopulation.specificContext);
+        value.values = observations;
       }
     }
   }


### PR DESCRIPTION
This will exclude measure populations that are in the MSRPOPLEX from the Observation. In order to test this, checkout the bonnie branch "fix_observ_msrpoplex". Using measure CMS32v6. 
[CMS32v6.xml.zip](https://github.com/projecttacoma/hqmf2js/files/1045801/CMS32v6.xml.zip)

Creating a patient that passes MSRPOPL and MSRPOPLEX the Observ should not be calculated at all. 


