### PR TITLE
made it so specific occurrences of the same type must be associated w…

### DIFF
--- a/test/unit/specifics_test.rb
+++ b/test/unit/specifics_test.rb
@@ -7,7 +7,7 @@ class SpecificsTest < Minitest::Test
     @context = get_js_context(HQMF2JS::Generator::JS.library_functions)
     test_initialize_js = 
     "
-      hqmf.SpecificsManager.initialize({},hqmfjs, {'id':'OccurrenceAEncounter', 'type':'Encounter', 'function':'SourceOccurrenceAEncounter'},{'id':'OccurrenceBEncounter', 'type':'Encounter', 'function':'SourceOccurrenceBEncounter'})
+      hqmf.SpecificsManager.initialize({},hqmfjs, {'id':'OccurrenceAEncounter', 'type':'OccA_Encounter', 'function':'SourceOccurrenceAEncounter'},{'id':'OccurrenceBEncounter', 'type':'OccB_Encounter', 'function':'SourceOccurrenceBEncounter'})
       hqmfjs.SourceOccurrenceAEncounter = function(patient) {
         return [{'id':1},{'id':2},{'id':3},{'id':4},{'id':5}]
       }


### PR DESCRIPTION
This is related to https://oncprojectracking.healthit.gov/support/browse/BONNIE-350.

See the conversation in the attached email thread.

[specific_occurrences_email_thread.docx](https://github.com/projecttacoma/hqmf2js/files/1252792/specific_occurrences_email_thread.docx)

I decided to go with a front end solution instead of a back-end solution because:

1. it's easier to test that it behaves as expected (can run a calculation regression test for a front end change. For a back-end change, need to test uploads of many measure to make sure we don't negatively impact things).
2. the front end change only modifies the value at the point where we know a bug was being caused by the existing values. We don't know where else these values are being used, if it's important to have OccurrenceA there, etc.
3. on the backend, this value is set in multiple places. It would be more error prone to change this because we may not catch all of the places where this value is set.
4. we are moving away from QDM and specific occurrences, so it doesn't make sense to invest lots of time in a more comprehensive solution.


To run the regression test, see the instructions here: https://github.com/projecttacoma/bonnie/wiki/Guide-to-Bonnie-Rake-Tasks#calculation-tests
THIS TAKES A REALLY LONG TIME!

There's a possibility that you will see one patient calculate "false" to "true" (depending on when the snapshot was taken).

JIRA test: https://jira.mitre.org/browse/BONNIE-996